### PR TITLE
Update standardverifier usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated proofs 
+data/
+
 # Compiler files
 cache/
 out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Generated proofs 
-data/
-
 # Compiler files
 cache/
 out/

--- a/src/standard/BaseStandardVerifier.sol
+++ b/src/standard/BaseStandardVerifier.sol
@@ -150,20 +150,6 @@ abstract contract BaseStandardVerifier {
     function loadVerificationKey(uint256 _vk, uint256 _omegaInverseLoc) internal pure virtual;
 
     /**
-     * @notice Get the number of public inputs required by the verification key
-     * @dev If made internal, this will mess with memory
-     * @return count The number of public inputs
-     */
-    function getPublicInputCount() external pure virtual returns (uint256 count) {
-        uint256 loc = 0x20;
-        loadVerificationKey(loc, 0x20);
-        assembly {
-            count := mload(add(loc, 0x20))
-        }
-        return count;
-    }
-
-    /**
      * @notice Verify a Standard Plonk proof
      * @param _proof - The serialized proof
      * @param _publicInputs - An array of the public inputs
@@ -226,7 +212,7 @@ abstract contract BaseStandardVerifier {
                     // @todo Add a test with recursive proofs to ensure that new formatting is still compatible
 
                     let public_inputs_ptr := add(calldataload(0x24), 0x24)
-                    let index_counter := add(mul(mload(RECURSIVE_PROOF_PUBLIC_INPUT_INDICES_LOC), 32), public_inputs_ptr)
+                    let index_counter := add(shl(mload(RECURSIVE_PROOF_PUBLIC_INPUT_INDICES_LOC), 5), public_inputs_ptr)
 
                     // Loads the recursive proof into memory.
                     // Each coordinate consist of 4 chunks of 68 bits, but take up 4 words in the proof.

--- a/src/standard/BaseStandardVerifier.sol
+++ b/src/standard/BaseStandardVerifier.sol
@@ -138,6 +138,16 @@ abstract contract BaseStandardVerifier {
 
     function loadVerificationKey(uint256 vk, uint256 _omegaInverseLoc) internal pure virtual;
 
+    function getPublicInputCount() external pure virtual returns (uint256 count) {
+        // don't make this internal, will fuck up your memory
+        uint256 loc = 0x20;
+        loadVerificationKey(loc, 0x20);
+        assembly {
+            count := mload(add(loc, 0x20))
+        }
+        return count;
+    }
+
     /**
      * @dev Verify a Plonk proof
      * @param - array of serialized proof data

--- a/test/Standard.t.sol
+++ b/test/Standard.t.sol
@@ -12,6 +12,8 @@ contract StandardTest is TestBase {
     StandardVerifier public verifier;
     DifferentialFuzzer public fuzzer;
 
+    uint256 public constant PUBLIC_INPUT_COUNT = 4;
+
     function setUp() public {
         verifier = new StandardVerifier();
         fuzzer = new DifferentialFuzzer().with_flavour(DifferentialFuzzer.PlonkFlavour.Standard);
@@ -24,19 +26,19 @@ contract StandardTest is TestBase {
         public_inputs[2] = input3;
 
         bytes memory proofData = fuzzer.with_public_inputs(public_inputs).generate_proof();
-        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, verifier.getPublicInputCount());
+        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, PUBLIC_INPUT_COUNT);
         assertTrue(verifier.verify(proof, publicInputs), "The proof is not valid");
     }
 
     function testValidProof() public {
         bytes memory proofData = fuzzer.generate_proof();
-        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, verifier.getPublicInputCount());
+        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, PUBLIC_INPUT_COUNT);
         assertTrue(verifier.verify(proof, publicInputs), "The proof is not valid");
     }
 
     function testProofFailure() public {
         bytes memory proofData = fuzzer.generate_proof();
-        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, verifier.getPublicInputCount());
+        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, PUBLIC_INPUT_COUNT);
 
         assembly {
             let where := add(add(proof, 0x20), mul(0x20, 2))
@@ -58,7 +60,7 @@ contract StandardTest is TestBase {
 
     function _testVerifierInvalidBn128Component(uint256 _offset) internal {
         bytes memory proofData = fuzzer.generate_proof();
-        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, verifier.getPublicInputCount());
+        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, PUBLIC_INPUT_COUNT);
 
         {
             uint256 q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
@@ -77,7 +79,7 @@ contract StandardTest is TestBase {
 
     function testPublicInputsNotInP(uint256 _offset) public {
         bytes memory proofData = fuzzer.generate_proof();
-        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, verifier.getPublicInputCount());
+        (bytes32[] memory publicInputs, bytes memory proof) = splitProof(proofData, PUBLIC_INPUT_COUNT);
 
         uint256 toReplace = bound(_offset, 0, publicInputs.length - 1);
         uint256 p = 21888242871839275222246405745257275088548364400416034343698204186575808495617;

--- a/test/Standard.t.sol
+++ b/test/Standard.t.sol
@@ -10,35 +10,30 @@ import {DifferentialFuzzer} from "./base/DifferentialFuzzer.sol";
 
 contract StandardTest is TestBase {
     StandardVerifier public verifier;
-    DifferentialFuzzer.PlonkFlavour public flavour;
+    DifferentialFuzzer public fuzzer;
 
     function setUp() public {
         verifier = new StandardVerifier();
-        flavour = DifferentialFuzzer.PlonkFlavour.Standard;
+        fuzzer = new DifferentialFuzzer().with_flavour(DifferentialFuzzer.PlonkFlavour.Standard);
     }
 
     function testFuzzProof(uint256 input1, uint256 input2, uint256 input3) public {
-        // TODO: move flavour to constructor
         uint256[] memory public_inputs = new uint256[](3);
         public_inputs[0] = input1;
         public_inputs[1] = input2;
         public_inputs[2] = input3;
 
-        bytes memory proof = new DifferentialFuzzer()
-            .with_flavour(flavour)
-            .with_public_inputs(public_inputs)
-            .generate_proof();
-
-        verifier.verify(proof);
+        bytes memory proof = fuzzer.with_public_inputs(public_inputs).generate_proof();
+        assertTrue(verifier.verify(proof), "The proof is not valid");
     }
 
     function testValidProof() public {
-        bytes memory proof = new DifferentialFuzzer().with_flavour(flavour).generate_proof();
+        bytes memory proof = fuzzer.generate_proof();
         assertTrue(verifier.verify(proof), "The proof is not valid");
     }
 
     function testProofFailure() public {
-        bytes memory proof = new DifferentialFuzzer().with_flavour(flavour).generate_proof();
+        bytes memory proof = fuzzer.generate_proof();
 
         assembly {
             let where := add(add(proof, 0x20), mul(0x20, 2))
@@ -59,7 +54,7 @@ contract StandardTest is TestBase {
     }
 
     function _testVerifierInvalidBn128Component(uint256 _offset) internal {
-        bytes memory proof = new DifferentialFuzzer().with_flavour(flavour).generate_proof();
+        bytes memory proof = fuzzer.generate_proof();
 
         {
             uint256 q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
@@ -77,7 +72,7 @@ contract StandardTest is TestBase {
     }
 
     function testPublicInputsNotInP(uint256 _offset) public {
-        bytes memory proof = new DifferentialFuzzer().with_flavour(flavour).generate_proof();
+        bytes memory proof = fuzzer.generate_proof();
         printBytes(proof, 0x00);
 
         uint256 toReplace = bound(_offset, 0, 3);

--- a/test/base/DifferentialFuzzer.sol
+++ b/test/base/DifferentialFuzzer.sol
@@ -49,7 +49,6 @@ contract DifferentialFuzzer is TestBase {
     // Encode public inputs as a comma seperated string for the ffi call
     function get_public_inputs() internal view returns (string memory public_input_params) {
         public_input_params = "";
-        console.log("public_inputs.length: %s", public_inputs.length);
         if (public_inputs.length > 0) {
             public_input_params = public_inputs[0].toString();
             for (uint256 i = 1; i < public_inputs.length; i++) {

--- a/test/base/TestBase.sol
+++ b/test/base/TestBase.sol
@@ -32,7 +32,7 @@ contract TestBase is Test {
 
     function splitProof(bytes memory _proofData, uint256 _numberOfPublicInputs)
         internal
-        pure
+        view
         returns (bytes32[] memory publicInputs, bytes memory proof)
     {
         publicInputs = new bytes32[](_numberOfPublicInputs);
@@ -42,15 +42,13 @@ contract TestBase is Test {
         }
 
         proof = new bytes(_proofData.length - (_numberOfPublicInputs * 0x20));
+        uint256 len = proof.length;
         assembly {
-            let wLoc := add(proof, 0x20)
-            let rLoc := add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs)))
-            let end := add(rLoc, mload(proof))
-
-            for {} lt(rLoc, end) {
-                wLoc := add(wLoc, 0x20)
-                rLoc := add(rLoc, 0x20)
-            } { mstore(wLoc, mload(rLoc)) }
+            pop(
+                staticcall(
+                    gas(), 0x4, add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs))), len, add(proof, 0x20), len
+                )
+            )
         }
     }
 

--- a/test/base/TestBase.sol
+++ b/test/base/TestBase.sol
@@ -3,8 +3,11 @@
 pragma solidity >=0.8.4;
 
 import {Test} from "forge-std/Test.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 contract TestBase is Test {
+    using Strings for uint256;
+
     function readProofData(string memory path) internal view returns (bytes memory) {
         // format [4 byte length][data]
         // Reads the raw bytes
@@ -27,6 +30,30 @@ contract TestBase is Test {
         return proofData;
     }
 
+    function splitProof(bytes memory _proofData, uint256 _numberOfPublicInputs)
+        internal
+        pure
+        returns (bytes32[] memory publicInputs, bytes memory proof)
+    {
+        publicInputs = new bytes32[](_numberOfPublicInputs);
+        for (uint256 i = 0; i < _numberOfPublicInputs; i++) {
+            // The proofs spit out by barretenberg have the public inputs at the beginning
+            publicInputs[i] = readWordByIndex(_proofData, i);
+        }
+
+        proof = new bytes(_proofData.length - (_numberOfPublicInputs * 0x20));
+        assembly {
+            let wLoc := add(proof, 0x20)
+            let rLoc := add(_proofData, add(0x20, mul(0x20, _numberOfPublicInputs)))
+            let end := add(rLoc, mload(proof))
+
+            for {} lt(rLoc, end) {
+                wLoc := add(wLoc, 0x20)
+                rLoc := add(rLoc, 0x20)
+            } { mstore(wLoc, mload(rLoc)) }
+        }
+    }
+
     function printBytes(bytes memory _data, uint256 _offset) internal {
         uint256 length = _data.length - _offset;
         for (uint256 i = 0; i < length / 0x20; i++) {
@@ -35,6 +62,12 @@ contract TestBase is Test {
                 val := mload(add(_offset, add(_data, mul(0x20, add(1, i)))))
             }
             emit log_named_bytes32(toHexString(bytes32(i * 0x20)), val);
+        }
+    }
+
+    function printList(bytes32[] memory _data, uint256 _offset) internal {
+        for (uint256 i = _offset; i < _data.length; i++) {
+            emit log_named_bytes32(i.toString(), _data[i]);
         }
     }
 


### PR DESCRIPTION
Replaces the `verify(bytes)` function with `verify(bytes proof, bytes32[] publicInputs)` to make it easier for devs to explicitly constrain publicInputs in their contracts before passing it into the verifier.

- Adds function to verifier to get the number of public inputs specified in the key. The implementation is very inefficient, but is not intended for consumption on-chain, so we can live with it.
- Adds function in `TestBase` to split barretenberg generated proofData into a proof part and a public inputs part. 
- Updates verify function signature
- Perform explicit for input length and return useful error.